### PR TITLE
Add README files across project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # ARQ.SIT
-repositorio tareas arq sistemas
+
+Repositorio de prácticas de Arquitectura de Sistemas. Contiene ejemplos de un gestor de tareas y servicios auxiliares implementados en Python.
+
+## Estructura principal
+
+- **client/** – Cliente o interfaz ligera para futuras pruebas.
+- **docker/** – Versión monolítica ejecutable mediante Docker.
+- **load_balancer/** – Aplicación web con balanceador de carga y UI de tareas.
+- **services/** – Conjunto de microservicios de ejemplo.
+
+Cada carpeta cuenta con su propio README con más detalles.

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,8 @@
+# 📂 client
+
+Pequeña carpeta con código de ejemplo para un cliente o interfaz que interactúe con el gestor de tareas. Actualmente contiene archivos de referencia:
+
+- `__init__.py`
+- `app.py`
+
+Se utiliza como base para futuras pruebas y desarrollo.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,16 @@
+# 📂 docker
+
+Archivos para ejecutar la versión monolítica del gestor de tareas dentro de un contenedor Docker.
+
+- `Dockerfile` – Imagen basada en Python 3.13.
+- `main.py` – Script interactivo para gestionar tareas en consola.
+- `tasks.json` – Ejemplo de archivo de almacenamiento.
+- `nomodular.puml` y `nomodular_2.puml` – Diagramas UML de referencia.
+
+```bash
+# Construir la imagen
+docker build -t tasks-cli .
+
+# Ejecutar el contenedor
+docker run --rm -it tasks-cli
+```

--- a/load_balancer/README.md
+++ b/load_balancer/README.md
@@ -1,31 +1,24 @@
-# 📌 Gestor de Tareas con Flask + Balanceador de Carga
+# 📂 load_balancer
 
-Una aplicación web construida con **Python y Flask** que permite gestionar tareas personales, con balanceo de carga entre múltiples instancias, monitoreo de salud y una interfaz visual moderna.
+Aplicación web construida con **Flask** que expone un gestor de tareas y un balanceador de carga para múltiples instancias.
 
----
+## Características
 
-## ✨ Funcionalidades
+- Interfaz HTML responsive para gestionar tareas.
+- API REST para operaciones CRUD.
+- Balanceador de carga con verificación de salud de los servidores.
+- Registro de eventos en un servicio externo de logs.
 
-- 🎨 Interfaz web responsiva y personalizable
-- 🔁 API REST para tareas (crear, listar, completar, eliminar)
-- ⚖️ Balanceador de carga con health-check automático
-- 📈 Dashboard de estado de servidores (`/status`)
-- 📦 Persistencia local con archivo JSON
-- 📝 Logging de eventos a servicio externo
-
----
-
-## 🧩 Arquitectura
-
-```plaintext
-              ┌────────────────────────┐
-              │ Balanceador (8080)     │
-              │ ─ Proxy + HealthCheck  │
-              └────────┬───────────────┘
-                       │
-        ┌──────────────┴──────────────┐
-        │                             │
-┌──────────────┐           ┌────────────────┐
-│ Flask 5001   │           │ Flask 5002     │
-│ Tareas       │           │ Tareas         │
-└──────────────┘           └────────────────┘
+```
+               ┌────────────────────────┐
+               │ Balanceador (8080)     │
+               │ ─ Proxy + HealthCheck  │
+               └────────┬───────────────┘
+                        │
+         ┌──────────────┴──────────────┐
+         │                             │
+  ┌──────────────┐           ┌────────────────┐
+  │ Flask 5001   │           │ Flask 5002     │
+  │ Gestor       │           │ Gestor         │
+  └──────────────┘           └────────────────┘
+```

--- a/services/README.md
+++ b/services/README.md
@@ -1,0 +1,10 @@
+# 📂 services
+
+Colección de microservicios utilizados por el proyecto. Cada carpeta representa un servicio independiente.
+
+- **logging_service/** – Guarda mensajes en un archivo de log.
+- **notification_service/** – Punto de partida para notificaciones.
+- **storage_service/** – Almacenamiento de tareas u otros datos.
+- **task_service/** – Lógica principal del gestor de tareas.
+
+Los servicios son ejemplos mínimos que pueden ampliarse según las necesidades.

--- a/services/logging_service/README.md
+++ b/services/logging_service/README.md
@@ -1,0 +1,10 @@
+# 📂 logging_service
+
+Servicio sencillo encargado de registrar mensajes en `log.txt`.
+
+Archivos principales:
+
+- `app.py` – Código base del servicio (placeholder).
+- `log.txt` – Archivo donde se almacenan los eventos.
+
+Este módulo puede ampliarse para centralizar el logging de la aplicación.

--- a/services/notification_service/README.md
+++ b/services/notification_service/README.md
@@ -1,0 +1,3 @@
+# 📂 notification_service
+
+Plantilla para un servicio de notificaciones. Actualmente contiene únicamente el archivo `app.py` y puede integrarse con servicios de correo o mensajería en el futuro.

--- a/services/storage_service/README.md
+++ b/services/storage_service/README.md
@@ -1,0 +1,10 @@
+# 📂 storage_service
+
+Servicio destinado al almacenamiento de datos. Incluye un archivo `tasks.json` vacío como ejemplo de persistencia.
+
+Archivos:
+
+- `app.py`
+- `tasks.json`
+
+Puede evolucionar para manejar una base de datos u otros mecanismos de almacenamiento.

--- a/services/task_service/README.md
+++ b/services/task_service/README.md
@@ -1,0 +1,3 @@
+# 📂 task_service
+
+Servicio que centraliza la lógica para administrar tareas. Incluye `app.py` y un `tasks.json` vacío como punto de partida.


### PR DESCRIPTION
## Summary
- create a main README describing each folder
- add READMEs for `client`, `docker`, `services`, and each sub-service
- update `load_balancer` README with concise description and diagram

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851924b3ab0832689f84e5236445392